### PR TITLE
+ Settings menu and GUI input overhaul

### DIFF
--- a/Scenes/MainScene.tscn
+++ b/Scenes/MainScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=65 format=2]
+[gd_scene load_steps=78 format=2]
 
 [ext_resource path="res://Assets/Sprites/OPLoop.png" type="Texture" id=1]
 [ext_resource path="res://Scripts/IntroLoopAnimatedSprite.gd" type="Script" id=2]
@@ -9,7 +9,6 @@
 [ext_resource path="res://Assets/Sprites/Start.aseprite" type="SpriteFrames" id=7]
 [ext_resource path="res://Assets/Sprites/OPIntro.png" type="Texture" id=8]
 [ext_resource path="res://Scripts/Menu.gd" type="Script" id=9]
-[ext_resource path="res://Assets/Fonts/Gamer.ttf" type="DynamicFontData" id=10]
 [ext_resource path="res://Scripts/ModToggle.gd" type="Script" id=11]
 [ext_resource path="res://Assets/Fonts/Early GameBoy.ttf" type="DynamicFontData" id=12]
 [ext_resource path="res://Assets/Audio/NG.mp3" type="AudioStream" id=13]
@@ -21,159 +20,659 @@
 [ext_resource path="res://Assets/Audio/OK2.mp3" type="AudioStream" id=19]
 
 [sub_resource type="AtlasTexture" id=1]
-atlas = ExtResource( 1 )
+atlas = ExtResource( 8 )
 region = Rect2( 0, 0, 240, 160 )
 
 [sub_resource type="AtlasTexture" id=2]
-atlas = ExtResource( 1 )
+atlas = ExtResource( 8 )
 region = Rect2( 240, 0, 240, 160 )
 
 [sub_resource type="AtlasTexture" id=3]
-atlas = ExtResource( 1 )
+atlas = ExtResource( 8 )
 region = Rect2( 480, 0, 240, 160 )
 
 [sub_resource type="AtlasTexture" id=4]
-atlas = ExtResource( 1 )
-region = Rect2( 0, 160, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=5]
-atlas = ExtResource( 1 )
-region = Rect2( 240, 160, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=6]
-atlas = ExtResource( 1 )
-region = Rect2( 480, 160, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=7]
-atlas = ExtResource( 1 )
-region = Rect2( 0, 320, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=8]
-atlas = ExtResource( 1 )
-region = Rect2( 240, 320, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=9]
-atlas = ExtResource( 1 )
-region = Rect2( 480, 320, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=10]
-atlas = ExtResource( 1 )
-region = Rect2( 0, 480, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=11]
-atlas = ExtResource( 1 )
-region = Rect2( 240, 480, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=12]
-atlas = ExtResource( 1 )
-region = Rect2( 480, 480, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=13]
-atlas = ExtResource( 8 )
-region = Rect2( 0, 0, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=14]
-atlas = ExtResource( 8 )
-region = Rect2( 240, 0, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=15]
-atlas = ExtResource( 8 )
-region = Rect2( 480, 0, 240, 160 )
-
-[sub_resource type="AtlasTexture" id=16]
 atlas = ExtResource( 8 )
 region = Rect2( 720, 0, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=17]
+[sub_resource type="AtlasTexture" id=5]
 atlas = ExtResource( 8 )
 region = Rect2( 960, 0, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=18]
+[sub_resource type="AtlasTexture" id=6]
 atlas = ExtResource( 8 )
 region = Rect2( 1200, 0, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=19]
+[sub_resource type="AtlasTexture" id=7]
 atlas = ExtResource( 8 )
 region = Rect2( 0, 160, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=20]
+[sub_resource type="AtlasTexture" id=8]
 atlas = ExtResource( 8 )
 region = Rect2( 240, 160, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=21]
+[sub_resource type="AtlasTexture" id=9]
 atlas = ExtResource( 8 )
 region = Rect2( 480, 160, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=22]
+[sub_resource type="AtlasTexture" id=10]
 atlas = ExtResource( 8 )
 region = Rect2( 720, 160, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=23]
+[sub_resource type="AtlasTexture" id=11]
 atlas = ExtResource( 8 )
 region = Rect2( 960, 160, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=24]
+[sub_resource type="AtlasTexture" id=12]
 atlas = ExtResource( 8 )
 region = Rect2( 1200, 160, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=25]
+[sub_resource type="AtlasTexture" id=13]
 atlas = ExtResource( 8 )
 region = Rect2( 0, 320, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=26]
+[sub_resource type="AtlasTexture" id=14]
 atlas = ExtResource( 8 )
 region = Rect2( 240, 320, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=27]
+[sub_resource type="AtlasTexture" id=15]
 atlas = ExtResource( 8 )
 region = Rect2( 480, 320, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=28]
+[sub_resource type="AtlasTexture" id=16]
 atlas = ExtResource( 8 )
 region = Rect2( 720, 320, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=29]
+[sub_resource type="AtlasTexture" id=17]
 atlas = ExtResource( 8 )
 region = Rect2( 960, 320, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=30]
+[sub_resource type="AtlasTexture" id=18]
 atlas = ExtResource( 8 )
 region = Rect2( 1200, 320, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=31]
+[sub_resource type="AtlasTexture" id=19]
 atlas = ExtResource( 8 )
 region = Rect2( 0, 480, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=32]
+[sub_resource type="AtlasTexture" id=20]
 atlas = ExtResource( 8 )
 region = Rect2( 240, 480, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=33]
+[sub_resource type="AtlasTexture" id=21]
 atlas = ExtResource( 8 )
 region = Rect2( 480, 480, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=34]
+[sub_resource type="AtlasTexture" id=22]
 atlas = ExtResource( 8 )
 region = Rect2( 720, 480, 240, 160 )
 
-[sub_resource type="AtlasTexture" id=35]
+[sub_resource type="AtlasTexture" id=23]
 atlas = ExtResource( 8 )
 region = Rect2( 960, 480, 240, 160 )
 
+[sub_resource type="AtlasTexture" id=24]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 0, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=25]
+atlas = ExtResource( 1 )
+region = Rect2( 240, 0, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=26]
+atlas = ExtResource( 1 )
+region = Rect2( 480, 0, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=27]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 160, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=28]
+atlas = ExtResource( 1 )
+region = Rect2( 240, 160, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=29]
+atlas = ExtResource( 1 )
+region = Rect2( 480, 160, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=30]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 320, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=31]
+atlas = ExtResource( 1 )
+region = Rect2( 240, 320, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=32]
+atlas = ExtResource( 1 )
+region = Rect2( 480, 320, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=33]
+atlas = ExtResource( 1 )
+region = Rect2( 0, 480, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=34]
+atlas = ExtResource( 1 )
+region = Rect2( 240, 480, 240, 160 )
+
+[sub_resource type="AtlasTexture" id=35]
+atlas = ExtResource( 1 )
+region = Rect2( 480, 480, 240, 160 )
+
 [sub_resource type="SpriteFrames" id=36]
 animations = [ {
-"frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ), SubResource( 4 ), SubResource( 5 ), SubResource( 6 ), SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ), SubResource( 12 ) ],
-"loop": true,
-"name": "Loop",
-"speed": 10.0
-}, {
-"frames": [ SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 23 ), SubResource( 24 ), SubResource( 25 ), SubResource( 26 ), SubResource( 27 ), SubResource( 28 ), SubResource( 29 ), SubResource( 30 ), SubResource( 31 ), SubResource( 32 ), SubResource( 33 ), SubResource( 34 ), SubResource( 35 ) ],
+"frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ), SubResource( 4 ), SubResource( 5 ), SubResource( 6 ), SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ), SubResource( 12 ), SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 23 ) ],
 "loop": false,
 "name": "Intro",
 "speed": 10.0
+}, {
+"frames": [ SubResource( 24 ), SubResource( 25 ), SubResource( 26 ), SubResource( 27 ), SubResource( 28 ), SubResource( 29 ), SubResource( 30 ), SubResource( 31 ), SubResource( 32 ), SubResource( 33 ), SubResource( 34 ), SubResource( 35 ) ],
+"loop": true,
+"name": "Loop",
+"speed": 10.0
 } ]
 
-[sub_resource type="Shader" id=37]
+[sub_resource type="DynamicFont" id=48]
+extra_spacing_char = -2
+font_data = ExtResource( 12 )
+
+[sub_resource type="StyleBoxFlat" id=38]
+content_margin_left = 16.0
+content_margin_right = 16.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 1, 1, 1, 0.188235 )
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color( 1, 1, 1, 1 )
+
+[sub_resource type="StyleBoxFlat" id=39]
+content_margin_left = 16.0
+content_margin_right = 16.0
+content_margin_top = 8.0
+content_margin_bottom = 8.0
+bg_color = Color( 0, 0, 0, 0 )
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color( 1, 1, 1, 1 )
+
+[sub_resource type="StyleBoxFlat" id=56]
+bg_color = Color( 0, 0, 0, 0.588235 )
+
+[sub_resource type="StyleBoxFlat" id=57]
+bg_color = Color( 0.258824, 0.258824, 0.258824, 0.588235 )
+
+[sub_resource type="StyleBoxFlat" id=58]
+bg_color = Color( 0.898039, 0.827451, 0.356863, 0.411765 )
+
+[sub_resource type="StyleBoxFlat" id=59]
+bg_color = Color( 0.898039, 0.356863, 0.356863, 0.411765 )
+
+[sub_resource type="StyleBoxFlat" id=60]
+bg_color = Color( 0.898039, 0.713726, 0.356863, 0.411765 )
+
+[sub_resource type="StyleBoxFlat" id=49]
+bg_color = Color( 0, 0, 0, 0.764706 )
+
+[sub_resource type="StyleBoxEmpty" id=50]
+
+[sub_resource type="StyleBoxFlat" id=54]
+content_margin_left = 16.0
+content_margin_right = 16.0
+bg_color = Color( 0, 0, 0, 0 )
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color( 1, 1, 1, 1 )
+
+[sub_resource type="StyleBoxFlat" id=55]
+content_margin_left = 16.0
+content_margin_right = 16.0
+bg_color = Color( 1, 1, 1, 0.188235 )
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color( 1, 1, 1, 1 )
+
+[sub_resource type="DynamicFont" id=40]
+font_data = ExtResource( 12 )
+
+[sub_resource type="Theme" id=41]
+default_font = SubResource( 40 )
+Button/colors/font_color = Color( 1, 1, 1, 1 )
+Button/colors/font_color_disabled = Color( 1, 1, 1, 1 )
+Button/colors/font_color_hover = Color( 1, 1, 1, 1 )
+Button/colors/font_color_pressed = Color( 0.482353, 0.482353, 0.482353, 1 )
+Button/constants/hseparation = 2
+Button/fonts/font = SubResource( 48 )
+Button/styles/disabled = null
+Button/styles/focus = SubResource( 38 )
+Button/styles/hover = SubResource( 38 )
+Button/styles/normal = SubResource( 39 )
+Button/styles/pressed = SubResource( 38 )
+CheckBox/colors/font_color = Color( 1, 1, 1, 1 )
+CheckBox/colors/font_color_disabled = Color( 1, 1, 1, 1 )
+CheckBox/colors/font_color_hover = Color( 1, 1, 1, 1 )
+CheckBox/colors/font_color_hover_pressed = Color( 1, 1, 1, 1 )
+CheckBox/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+CheckBox/constants/check_vadjust = 0
+CheckBox/constants/hseparation = 4
+CheckBox/fonts/font = null
+CheckBox/icons/checked = null
+CheckBox/icons/radio_checked = null
+CheckBox/icons/radio_unchecked = null
+CheckBox/icons/unchecked = null
+CheckBox/styles/disabled = null
+CheckBox/styles/focus = null
+CheckBox/styles/hover = null
+CheckBox/styles/hover_pressed = null
+CheckBox/styles/normal = null
+CheckBox/styles/pressed = null
+CheckButton/colors/font_color = Color( 1, 1, 1, 1 )
+CheckButton/colors/font_color_disabled = Color( 1, 1, 1, 1 )
+CheckButton/colors/font_color_hover = Color( 1, 1, 1, 1 )
+CheckButton/colors/font_color_hover_pressed = Color( 1, 1, 1, 1 )
+CheckButton/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+CheckButton/constants/check_vadjust = 0
+CheckButton/constants/hseparation = 4
+CheckButton/fonts/font = null
+CheckButton/icons/off = null
+CheckButton/icons/off_disabled = null
+CheckButton/icons/on = null
+CheckButton/icons/on_disabled = null
+CheckButton/styles/disabled = null
+CheckButton/styles/focus = null
+CheckButton/styles/hover = null
+CheckButton/styles/hover_pressed = null
+CheckButton/styles/normal = null
+CheckButton/styles/pressed = null
+ColorPicker/constants/h_width = 30
+ColorPicker/constants/label_width = 10
+ColorPicker/constants/margin = 4
+ColorPicker/constants/sv_height = 256
+ColorPicker/constants/sv_width = 256
+ColorPicker/icons/add_preset = null
+ColorPicker/icons/color_hue = null
+ColorPicker/icons/color_sample = null
+ColorPicker/icons/overbright_indicator = null
+ColorPicker/icons/preset_bg = null
+ColorPicker/icons/screen_picker = null
+ColorPickerButton/colors/font_color = Color( 0, 0, 0, 1 )
+ColorPickerButton/colors/font_color_disabled = Color( 0, 0, 0, 1 )
+ColorPickerButton/colors/font_color_hover = Color( 0, 0, 0, 1 )
+ColorPickerButton/colors/font_color_pressed = Color( 0, 0, 0, 1 )
+ColorPickerButton/constants/hseparation = 2
+ColorPickerButton/fonts/font = null
+ColorPickerButton/icons/bg = null
+ColorPickerButton/styles/disabled = null
+ColorPickerButton/styles/focus = null
+ColorPickerButton/styles/hover = null
+ColorPickerButton/styles/normal = null
+ColorPickerButton/styles/pressed = null
+Dialogs/constants/button_margin = 32
+Dialogs/constants/margin = 8
+FileDialog/colors/file_icon_modulate = Color( 0, 0, 0, 1 )
+FileDialog/colors/files_disabled = Color( 0, 0, 0, 1 )
+FileDialog/colors/folder_icon_modulate = Color( 0, 0, 0, 1 )
+FileDialog/icons/file = null
+FileDialog/icons/folder = null
+FileDialog/icons/parent_folder = null
+FileDialog/icons/reload = null
+FileDialog/icons/toggle_hidden = null
+Fonts/fonts/large = null
+Fonts/fonts/normal = null
+GraphEdit/colors/activity = Color( 0, 0, 0, 1 )
+GraphEdit/colors/grid_major = Color( 0, 0, 0, 1 )
+GraphEdit/colors/grid_minor = Color( 0, 0, 0, 1 )
+GraphEdit/colors/selection_fill = Color( 0, 0, 0, 1 )
+GraphEdit/colors/selection_stroke = Color( 0, 0, 0, 1 )
+GraphEdit/constants/bezier_len_neg = 160
+GraphEdit/constants/bezier_len_pos = 80
+GraphEdit/constants/port_grab_distance_horizontal = 48
+GraphEdit/constants/port_grab_distance_vertical = 6
+GraphEdit/icons/minimap = null
+GraphEdit/icons/minus = null
+GraphEdit/icons/more = null
+GraphEdit/icons/reset = null
+GraphEdit/icons/snap = null
+GraphEdit/styles/bg = null
+GraphEditMinimap/colors/resizer_color = Color( 0, 0, 0, 1 )
+GraphEditMinimap/icons/resizer = null
+GraphEditMinimap/styles/bg = null
+GraphEditMinimap/styles/camera = null
+GraphEditMinimap/styles/node = null
+GraphNode/colors/close_color = Color( 0, 0, 0, 1 )
+GraphNode/colors/resizer_color = Color( 0, 0, 0, 1 )
+GraphNode/colors/title_color = Color( 0, 0, 0, 1 )
+GraphNode/constants/close_offset = 18
+GraphNode/constants/port_offset = 3
+GraphNode/constants/separation = 1
+GraphNode/constants/title_offset = 20
+GraphNode/fonts/title_font = null
+GraphNode/icons/close = null
+GraphNode/icons/port = null
+GraphNode/icons/resizer = null
+GraphNode/styles/breakpoint = null
+GraphNode/styles/comment = null
+GraphNode/styles/commentfocus = null
+GraphNode/styles/defaultfocus = null
+GraphNode/styles/defaultframe = null
+GraphNode/styles/frame = null
+GraphNode/styles/position = null
+GraphNode/styles/selectedframe = null
+GridContainer/constants/hseparation = 4
+GridContainer/constants/vseparation = 4
+HBoxContainer/constants/separation = 4
+HScrollBar/icons/decrement = null
+HScrollBar/icons/decrement_highlight = null
+HScrollBar/icons/increment = null
+HScrollBar/icons/increment_highlight = null
+HScrollBar/styles/grabber = null
+HScrollBar/styles/grabber_highlight = null
+HScrollBar/styles/grabber_pressed = null
+HScrollBar/styles/scroll = null
+HScrollBar/styles/scroll_focus = null
+HSeparator/constants/separation = 4
+HSeparator/styles/separator = null
+HSlider/icons/grabber = null
+HSlider/icons/grabber_disabled = null
+HSlider/icons/grabber_highlight = null
+HSlider/icons/tick = null
+HSlider/styles/grabber_area = null
+HSlider/styles/grabber_area_highlight = null
+HSlider/styles/slider = null
+HSplitContainer/constants/autohide = 1
+HSplitContainer/constants/separation = 12
+HSplitContainer/icons/grabber = null
+HSplitContainer/styles/bg = null
+Icons/icons/close = null
+ItemList/colors/font_color = Color( 1, 1, 1, 1 )
+ItemList/colors/font_color_selected = Color( 1, 1, 1, 1 )
+ItemList/colors/guide_color = Color( 1, 1, 1, 1 )
+ItemList/constants/hseparation = 4
+ItemList/constants/icon_margin = 4
+ItemList/constants/line_separation = 2
+ItemList/constants/vseparation = 2
+ItemList/fonts/font = null
+ItemList/styles/bg = SubResource( 56 )
+ItemList/styles/bg_focus = SubResource( 57 )
+ItemList/styles/cursor = SubResource( 58 )
+ItemList/styles/cursor_unfocused = null
+ItemList/styles/selected = SubResource( 59 )
+ItemList/styles/selected_focus = SubResource( 60 )
+Label/colors/font_color = Color( 1, 1, 1, 1 )
+Label/colors/font_color_shadow = Color( 0, 0, 0, 1 )
+Label/colors/font_outline_modulate = Color( 0, 0, 0, 1 )
+Label/constants/line_spacing = 3
+Label/constants/shadow_as_outline = 0
+Label/constants/shadow_offset_x = 1
+Label/constants/shadow_offset_y = 1
+Label/fonts/font = null
+Label/styles/normal = null
+LineEdit/colors/clear_button_color = Color( 0, 0, 0, 1 )
+LineEdit/colors/clear_button_color_pressed = Color( 0, 0, 0, 1 )
+LineEdit/colors/cursor_color = Color( 0, 0, 0, 1 )
+LineEdit/colors/font_color = Color( 0, 0, 0, 1 )
+LineEdit/colors/font_color_selected = Color( 0, 0, 0, 1 )
+LineEdit/colors/font_color_uneditable = Color( 0, 0, 0, 1 )
+LineEdit/colors/selection_color = Color( 0, 0, 0, 1 )
+LineEdit/constants/minimum_spaces = 12
+LineEdit/fonts/font = null
+LineEdit/icons/clear = null
+LineEdit/styles/focus = null
+LineEdit/styles/normal = null
+LineEdit/styles/read_only = null
+LinkButton/colors/font_color = Color( 0, 0, 0, 1 )
+LinkButton/colors/font_color_hover = Color( 0, 0, 0, 1 )
+LinkButton/colors/font_color_pressed = Color( 0, 0, 0, 1 )
+LinkButton/constants/underline_spacing = 2
+LinkButton/fonts/font = null
+LinkButton/styles/focus = null
+MarginContainer/constants/margin_bottom = 0
+MarginContainer/constants/margin_left = 0
+MarginContainer/constants/margin_right = 0
+MarginContainer/constants/margin_top = 0
+MenuButton/colors/font_color = Color( 1, 1, 1, 1 )
+MenuButton/colors/font_color_disabled = Color( 1, 1, 1, 1 )
+MenuButton/colors/font_color_hover = Color( 1, 1, 1, 1 )
+MenuButton/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+MenuButton/constants/hseparation = 3
+MenuButton/fonts/font = null
+MenuButton/styles/disabled = null
+MenuButton/styles/focus = null
+MenuButton/styles/hover = null
+MenuButton/styles/normal = null
+MenuButton/styles/pressed = null
+OptionButton/colors/font_color = Color( 1, 1, 1, 1 )
+OptionButton/colors/font_color_disabled = Color( 1, 1, 1, 1 )
+OptionButton/colors/font_color_hover = Color( 1, 1, 1, 1 )
+OptionButton/colors/font_color_pressed = Color( 1, 1, 1, 1 )
+OptionButton/constants/arrow_margin = 2
+OptionButton/constants/hseparation = 2
+OptionButton/fonts/font = null
+OptionButton/icons/arrow = null
+OptionButton/styles/disabled = null
+OptionButton/styles/focus = null
+OptionButton/styles/hover = null
+OptionButton/styles/normal = null
+OptionButton/styles/pressed = null
+Panel/styles/panel = SubResource( 49 )
+PanelContainer/styles/panel = null
+PopupDialog/styles/panel = null
+PopupMenu/colors/font_color = Color( 0, 0, 0, 1 )
+PopupMenu/colors/font_color_accel = Color( 0, 0, 0, 1 )
+PopupMenu/colors/font_color_disabled = Color( 0, 0, 0, 1 )
+PopupMenu/colors/font_color_hover = Color( 0, 0, 0, 1 )
+PopupMenu/colors/font_color_separator = Color( 0, 0, 0, 1 )
+PopupMenu/constants/hseparation = 4
+PopupMenu/constants/vseparation = 4
+PopupMenu/fonts/font = null
+PopupMenu/icons/checked = null
+PopupMenu/icons/radio_checked = null
+PopupMenu/icons/radio_unchecked = null
+PopupMenu/icons/submenu = null
+PopupMenu/icons/unchecked = null
+PopupMenu/styles/hover = null
+PopupMenu/styles/labeled_separator_left = null
+PopupMenu/styles/labeled_separator_right = null
+PopupMenu/styles/panel = null
+PopupMenu/styles/panel_disabled = null
+PopupMenu/styles/separator = null
+PopupPanel/styles/panel = null
+ProgressBar/colors/font_color = Color( 0, 0, 0, 1 )
+ProgressBar/colors/font_color_shadow = Color( 0, 0, 0, 1 )
+ProgressBar/fonts/font = null
+ProgressBar/styles/bg = null
+ProgressBar/styles/fg = null
+RichTextLabel/colors/default_color = Color( 0, 0, 0, 1 )
+RichTextLabel/colors/font_color_selected = Color( 0, 0, 0, 1 )
+RichTextLabel/colors/font_color_shadow = Color( 0, 0, 0, 1 )
+RichTextLabel/colors/selection_color = Color( 0, 0, 0, 1 )
+RichTextLabel/constants/line_separation = 1
+RichTextLabel/constants/shadow_as_outline = 0
+RichTextLabel/constants/shadow_offset_x = 1
+RichTextLabel/constants/shadow_offset_y = 1
+RichTextLabel/constants/table_hseparation = 3
+RichTextLabel/constants/table_vseparation = 3
+RichTextLabel/fonts/bold_font = null
+RichTextLabel/fonts/bold_italics_font = null
+RichTextLabel/fonts/italics_font = null
+RichTextLabel/fonts/mono_font = null
+RichTextLabel/fonts/normal_font = null
+RichTextLabel/styles/focus = null
+RichTextLabel/styles/normal = null
+ScrollContainer/styles/bg = null
+SpinBox/icons/updown = null
+TabContainer/colors/font_color_bg = Color( 1, 1, 1, 1 )
+TabContainer/colors/font_color_disabled = Color( 0, 0, 0, 1 )
+TabContainer/colors/font_color_fg = Color( 1, 1, 1, 1 )
+TabContainer/constants/hseparation = 12
+TabContainer/constants/label_valign_bg = 2
+TabContainer/constants/label_valign_fg = 0
+TabContainer/constants/side_margin = 10
+TabContainer/constants/top_margin = 24
+TabContainer/fonts/font = null
+TabContainer/icons/decrement = null
+TabContainer/icons/decrement_highlight = null
+TabContainer/icons/increment = null
+TabContainer/icons/increment_highlight = null
+TabContainer/icons/menu = null
+TabContainer/icons/menu_highlight = null
+TabContainer/styles/panel = SubResource( 50 )
+TabContainer/styles/tab_bg = SubResource( 54 )
+TabContainer/styles/tab_disabled = null
+TabContainer/styles/tab_fg = SubResource( 55 )
+Tabs/colors/font_color_bg = Color( 0, 0, 0, 1 )
+Tabs/colors/font_color_disabled = Color( 0, 0, 0, 1 )
+Tabs/colors/font_color_fg = Color( 0, 0, 0, 1 )
+Tabs/constants/hseparation = 4
+Tabs/constants/label_valign_bg = 2
+Tabs/constants/label_valign_fg = 0
+Tabs/constants/top_margin = 24
+Tabs/fonts/font = null
+Tabs/icons/close = null
+Tabs/icons/decrement = null
+Tabs/icons/decrement_highlight = null
+Tabs/icons/increment = null
+Tabs/icons/increment_highlight = null
+Tabs/styles/button = null
+Tabs/styles/button_pressed = null
+Tabs/styles/panel = null
+Tabs/styles/tab_bg = null
+Tabs/styles/tab_disabled = null
+Tabs/styles/tab_fg = null
+TextEdit/colors/background_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/bookmark_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/brace_mismatch_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/breakpoint_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/caret_background_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/caret_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/code_folding_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/completion_background_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/completion_existing_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/completion_font_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/completion_scroll_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/completion_selected_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/current_line_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/executing_line_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/font_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/font_color_readonly = Color( 0, 0, 0, 1 )
+TextEdit/colors/font_color_selected = Color( 0, 0, 0, 1 )
+TextEdit/colors/function_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/line_number_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/mark_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/member_variable_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/number_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/safe_line_number_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/selection_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/symbol_color = Color( 0, 0, 0, 1 )
+TextEdit/colors/word_highlighted_color = Color( 0, 0, 0, 1 )
+TextEdit/constants/completion_lines = 7
+TextEdit/constants/completion_max_width = 50
+TextEdit/constants/completion_scroll_width = 3
+TextEdit/constants/line_spacing = 4
+TextEdit/fonts/font = null
+TextEdit/icons/fold = null
+TextEdit/icons/folded = null
+TextEdit/icons/space = null
+TextEdit/icons/tab = null
+TextEdit/styles/completion = null
+TextEdit/styles/focus = null
+TextEdit/styles/normal = null
+TextEdit/styles/read_only = null
+ToolButton/colors/font_color = Color( 0, 0, 0, 1 )
+ToolButton/colors/font_color_disabled = Color( 0, 0, 0, 1 )
+ToolButton/colors/font_color_hover = Color( 0, 0, 0, 1 )
+ToolButton/colors/font_color_pressed = Color( 0, 0, 0, 1 )
+ToolButton/constants/hseparation = 3
+ToolButton/fonts/font = null
+ToolButton/styles/disabled = null
+ToolButton/styles/focus = null
+ToolButton/styles/hover = null
+ToolButton/styles/normal = null
+ToolButton/styles/pressed = null
+TooltipLabel/colors/font_color = Color( 0, 0, 0, 1 )
+TooltipLabel/colors/font_color_shadow = Color( 0, 0, 0, 1 )
+TooltipLabel/constants/shadow_offset_x = 1
+TooltipLabel/constants/shadow_offset_y = 1
+TooltipLabel/fonts/font = null
+TooltipPanel/styles/panel = null
+Tree/colors/custom_button_font_highlight = Color( 0, 0, 0, 1 )
+Tree/colors/drop_position_color = Color( 0, 0, 0, 1 )
+Tree/colors/font_color = Color( 0, 0, 0, 1 )
+Tree/colors/font_color_selected = Color( 0, 0, 0, 1 )
+Tree/colors/guide_color = Color( 0, 0, 0, 1 )
+Tree/colors/relationship_line_color = Color( 0, 0, 0, 1 )
+Tree/colors/title_button_color = Color( 0, 0, 0, 1 )
+Tree/constants/button_margin = 4
+Tree/constants/draw_guides = 1
+Tree/constants/draw_relationship_lines = 0
+Tree/constants/hseparation = 4
+Tree/constants/item_margin = 12
+Tree/constants/scroll_border = 4
+Tree/constants/scroll_speed = 12
+Tree/constants/vseparation = 4
+Tree/fonts/font = null
+Tree/fonts/title_button_font = null
+Tree/icons/arrow = null
+Tree/icons/arrow_collapsed = null
+Tree/icons/checked = null
+Tree/icons/select_arrow = null
+Tree/icons/unchecked = null
+Tree/icons/updown = null
+Tree/styles/bg = null
+Tree/styles/bg_focus = null
+Tree/styles/button_pressed = null
+Tree/styles/cursor = null
+Tree/styles/cursor_unfocused = null
+Tree/styles/custom_button = null
+Tree/styles/custom_button_hover = null
+Tree/styles/custom_button_pressed = null
+Tree/styles/selected = null
+Tree/styles/selected_focus = null
+Tree/styles/title_button_hover = null
+Tree/styles/title_button_normal = null
+Tree/styles/title_button_pressed = null
+VBoxContainer/constants/separation = 4
+VScrollBar/icons/decrement = null
+VScrollBar/icons/decrement_highlight = null
+VScrollBar/icons/increment = null
+VScrollBar/icons/increment_highlight = null
+VScrollBar/styles/grabber = null
+VScrollBar/styles/grabber_highlight = null
+VScrollBar/styles/grabber_pressed = null
+VScrollBar/styles/scroll = null
+VScrollBar/styles/scroll_focus = null
+VSeparator/constants/separation = 4
+VSeparator/styles/separator = null
+VSlider/icons/grabber = null
+VSlider/icons/grabber_disabled = null
+VSlider/icons/grabber_highlight = null
+VSlider/icons/tick = null
+VSlider/styles/grabber_area = null
+VSlider/styles/grabber_area_highlight = null
+VSlider/styles/slider = null
+VSplitContainer/constants/autohide = 1
+VSplitContainer/constants/separation = 12
+VSplitContainer/icons/grabber = null
+VSplitContainer/styles/bg = null
+WindowDialog/colors/title_color = Color( 0, 0, 0, 1 )
+WindowDialog/constants/close_h_ofs = 18
+WindowDialog/constants/close_v_ofs = 18
+WindowDialog/constants/scaleborder_size = 4
+WindowDialog/constants/title_height = 20
+WindowDialog/fonts/title_font = null
+WindowDialog/icons/close = null
+WindowDialog/icons/close_highlight = null
+WindowDialog/styles/panel = null
+
+[sub_resource type="Shader" id=42]
 code = "shader_type canvas_item;
 
 uniform float blur_amount : hint_range(0, 5);
@@ -182,27 +681,33 @@ void fragment() {
 	COLOR = textureLod(SCREEN_TEXTURE, SCREEN_UV, blur_amount);
 }"
 
-[sub_resource type="ShaderMaterial" id=38]
-shader = SubResource( 37 )
+[sub_resource type="ShaderMaterial" id=43]
+shader = SubResource( 42 )
 shader_param/blur_amount = 0.0
 
-[sub_resource type="DynamicFont" id=39]
+[sub_resource type="DynamicFont" id=44]
 size = 12
 font_data = ExtResource( 12 )
 
-[sub_resource type="DynamicFont" id=40]
+[sub_resource type="DynamicFont" id=45]
 size = 32
 font_data = ExtResource( 12 )
 
-[sub_resource type="DynamicFont" id=41]
+[sub_resource type="DynamicFont" id=46]
 size = 24
 font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxEmpty" id=42]
+[sub_resource type="DynamicFont" id=51]
+size = 32
+extra_spacing_char = -5
+font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxEmpty" id=43]
+[sub_resource type="DynamicFont" id=52]
+size = 32
+extra_spacing_char = -5
+font_data = ExtResource( 12 )
 
-[sub_resource type="StyleBoxFlat" id=44]
+[sub_resource type="StyleBoxFlat" id=47]
 bg_color = Color( 0, 0, 0, 0 )
 border_width_left = 4
 border_width_top = 4
@@ -210,9 +715,10 @@ border_width_right = 4
 border_width_bottom = 4
 border_color = Color( 1, 1, 1, 1 )
 
-[sub_resource type="DynamicFont" id=45]
-size = 64
-font_data = ExtResource( 10 )
+[sub_resource type="DynamicFont" id=53]
+size = 32
+extra_spacing_char = -5
+font_data = ExtResource( 12 )
 
 [node name="MainScene" type="Node2D"]
 script = ExtResource( 3 )
@@ -221,6 +727,7 @@ script = ExtResource( 3 )
 scale = Vector2( 4, 4 )
 frames = SubResource( 36 )
 animation = "Loop"
+frame = 6
 centered = false
 script = ExtResource( 2 )
 
@@ -249,154 +756,201 @@ autoplay = true
 
 [node name="Menu" type="Control" parent="."]
 visible = false
-margin_right = 40.0
-margin_bottom = 40.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = 960.0
+margin_bottom = 640.0
+rect_min_size = Vector2( 940, 640 )
+theme = SubResource( 41 )
 script = ExtResource( 9 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="BlurShader" type="ColorRect" parent="Menu"]
-material = SubResource( 38 )
-margin_right = 960.0
-margin_bottom = 640.0
+material = SubResource( 43 )
+anchor_right = 1.0
+anchor_bottom = 1.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="SettingsWindow" type="WindowDialog" parent="Menu"]
-margin_left = 25.0
-margin_top = 45.0
-margin_right = 525.0
-margin_bottom = 545.0
-window_title = "Settings window"
-resizable = true
+[node name="SettingsWindow" type="Panel" parent="Menu"]
+visible = false
+anchor_bottom = 1.0
+margin_right = 588.0
 __meta__ = {
-"_edit_lock_": true,
 "_edit_use_anchors_": false
 }
 
 [node name="Tabs" type="TabContainer" parent="Menu/SettingsWindow"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-drag_to_rearrange_enabled = true
+margin_top = 20.0
 __meta__ = {
 "_edit_lock_": true,
 "_edit_use_anchors_": false
 }
 
 [node name="Settings" type="Control" parent="Menu/SettingsWindow/Tabs"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = 32.0
-margin_right = -4.0
-margin_bottom = -4.0
+margin_top = 30.0
 __meta__ = {
 "_edit_lock_": true,
 "_edit_use_anchors_": false
 }
 
-[node name="Fullscreen" type="CheckButton" parent="Menu/SettingsWindow/Tabs/Settings"]
-margin_right = 76.0
-margin_bottom = 40.0
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/SettingsWindow/Tabs/Settings"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 30.0
+margin_top = 20.0
+margin_right = -30.0
+margin_bottom = -30.0
+custom_constants/separation = 5
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Fullscreen" type="CheckButton" parent="Menu/SettingsWindow/Tabs/Settings/VBoxContainer"]
+margin_right = 528.0
+margin_bottom = 48.0
+focus_neighbour_top = NodePath("../CaptureAme")
+focus_previous = NodePath("../CaptureAme")
 text = "Fullscreen"
+clip_text = true
 script = ExtResource( 14 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="SpeedUpPot" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Settings"]
-margin_top = 40.0
-margin_right = 146.0
-margin_bottom = 80.0
-text = "Experimental feature: Speed up pot sequence"
+[node name="Control" type="Control" parent="Menu/SettingsWindow/Tabs/Settings/VBoxContainer"]
+margin_top = 53.0
+margin_right = 528.0
+margin_bottom = 83.0
+rect_min_size = Vector2( 0, 30 )
+
+[node name="Label" type="Label" parent="Menu/SettingsWindow/Tabs/Settings/VBoxContainer"]
+margin_top = 88.0
+margin_right = 528.0
+margin_bottom = 108.0
+text = "Experimental features"
+
+[node name="SpeedUpPot" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Settings/VBoxContainer"]
+margin_top = 113.0
+margin_right = 528.0
+margin_bottom = 149.0
+text = "Speed up pot sequence"
+clip_text = true
 script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="CaptureAme" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Settings"]
-margin_top = 80.0
-margin_right = 319.0
-margin_bottom = 120.0
-text = "Experimental fun feature: Export stretched pictures of Amelia Watson"
+[node name="CaptureAme" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Settings/VBoxContainer"]
+margin_top = 154.0
+margin_right = 528.0
+margin_bottom = 190.0
+focus_neighbour_bottom = NodePath("../Fullscreen")
+focus_next = NodePath("../Fullscreen")
+text = "Export images of Amelia Watson"
+clip_text = true
 script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Mods" type="Control" parent="Menu/SettingsWindow/Tabs"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = 32.0
-margin_right = -4.0
-margin_bottom = -4.0
+margin_top = 30.0
 __meta__ = {
 "_edit_lock_": true,
 "_edit_use_anchors_": false
 }
 
-[node name="InvControls" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods"]
-margin_right = 24.0
-margin_bottom = 24.0
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/SettingsWindow/Tabs/Mods"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 30.0
+margin_top = 20.0
+margin_right = -30.0
+margin_bottom = -30.0
+size_flags_horizontal = 7
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="InvControls" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer"]
+margin_right = 528.0
+margin_bottom = 36.0
+focus_previous = NodePath("../Distraction")
 text = "Inverted Controls"
 script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="InvColors" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods"]
-margin_top = 24.0
-margin_right = 139.0
-margin_bottom = 48.0
+[node name="InvColors" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer"]
+margin_top = 40.0
+margin_right = 528.0
+margin_bottom = 76.0
 text = "Inverted Colors"
 script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LTW" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods"]
-margin_top = 48.0
-margin_right = 139.0
-margin_bottom = 72.0
+[node name="LTW" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer"]
+margin_top = 80.0
+margin_right = 528.0
+margin_bottom = 116.0
 text = "Lose to win"
 script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Distraction" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods"]
-margin_top = 72.0
-margin_right = 139.0
-margin_bottom = 96.0
+[node name="Distraction" type="CheckBox" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer"]
+margin_top = 120.0
+margin_right = 528.0
+margin_bottom = 156.0
 text = "Distraction"
 script = ExtResource( 11 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Minigames" type="Control" parent="Menu/SettingsWindow/Tabs/Mods"]
-margin_top = 96.0
-margin_right = 492.0
-margin_bottom = 464.0
+[node name="Label" type="Label" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer"]
+margin_top = 160.0
+margin_right = 528.0
+margin_bottom = 203.0
+text = "
+Game modes:"
+
+[node name="Minigames" type="Control" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer"]
+margin_top = 207.0
+margin_right = 528.0
+margin_bottom = 540.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource( 17 )
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="VSeparator" type="VSeparator" parent="Menu/SettingsWindow/Tabs/Mods/Minigames"]
-margin_right = 492.0
-margin_bottom = 368.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="InactiveMinigames" type="ItemList" parent="Menu/SettingsWindow/Tabs/Mods/Minigames"]
-margin_right = 225.0
-margin_bottom = 368.0
+[node name="InactiveMinigames" type="ItemList" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames/HBoxContainer"]
+margin_right = 258.0
+margin_bottom = 333.0
+focus_neighbour_right = NodePath("../ActiveMinigames")
+size_flags_horizontal = 3
+size_flags_vertical = 3
 select_mode = 1
 allow_reselect = true
 allow_rmb_select = true
@@ -404,61 +958,90 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="ActiveMinigames" type="ItemList" parent="Menu/SettingsWindow/Tabs/Mods/Minigames"]
-margin_left = 267.0
-margin_right = 492.0
-margin_bottom = 368.0
-select_mode = 1
-allow_reselect = true
-allow_rmb_select = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="MoveLeft" type="Button" parent="Menu/SettingsWindow/Tabs/Mods/Minigames"]
-margin_left = 226.0
-margin_top = 124.0
+[node name="VSeparator" type="VSeparator" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames/HBoxContainer"]
+margin_left = 262.0
 margin_right = 266.0
-margin_bottom = 164.0
+margin_bottom = 333.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ActiveMinigames" type="ItemList" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames/HBoxContainer"]
+margin_left = 270.0
+margin_right = 528.0
+margin_bottom = 333.0
+focus_neighbour_left = NodePath("../InactiveMinigames")
+focus_next = NodePath("../../../InvControls")
+size_flags_horizontal = 3
+select_mode = 1
+allow_reselect = true
+allow_rmb_select = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="MoveLeft" type="Button" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -28.0
+margin_top = -39.0
+margin_right = 28.0
+margin_bottom = 1.0
 icon = ExtResource( 15 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="MoveRight" type="Button" parent="Menu/SettingsWindow/Tabs/Mods/Minigames"]
-margin_left = 226.0
-margin_top = 204.0
-margin_right = 266.0
-margin_bottom = 244.0
+[node name="MoveRight" type="Button" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -28.0
+margin_top = 6.0
+margin_right = 28.0
+margin_bottom = 46.0
 icon = ExtResource( 16 )
-
-[node name="DisabledMinigamesLabel" type="Label" parent="Menu/SettingsWindow/Tabs/Mods/Minigames"]
-margin_top = 354.0
-margin_right = 225.0
-margin_bottom = 368.0
-custom_colors/font_color = Color( 1, 1, 1, 0.25098 )
-text = "Disabled minigames"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="EnabledMinigamesLabel" type="Label" parent="Menu/SettingsWindow/Tabs/Mods/Minigames"]
-margin_left = 267.0
-margin_top = 354.0
-margin_right = 492.0
-margin_bottom = 368.0
+[node name="DisabledMinigamesLabel" type="Label" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames"]
+anchor_top = 1.0
+anchor_bottom = 1.0
+margin_left = 8.0
+margin_top = -24.0
+margin_right = 136.0
+margin_bottom = -4.0
 custom_colors/font_color = Color( 1, 1, 1, 0.25098 )
-text = "Enabled minigames"
+text = "Disabled"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="EnabledMinigamesLabel" type="Label" parent="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -117.0
+margin_top = -24.0
+margin_right = -5.0
+margin_bottom = -4.0
+custom_colors/font_color = Color( 1, 1, 1, 0.25098 )
+text = "Enabled"
 align = 2
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Credits" type="Control" parent="Menu/SettingsWindow/Tabs"]
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = 32.0
-margin_right = -4.0
-margin_bottom = -4.0
+margin_top = 30.0
 __meta__ = {
 "_edit_lock_": true,
 "_edit_use_anchors_": false
@@ -467,9 +1050,14 @@ __meta__ = {
 [node name="RichTextLabel" type="RichTextLabel" parent="Menu/SettingsWindow/Tabs/Credits"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_fonts/italics_font = SubResource( 39 )
-custom_fonts/bold_font = SubResource( 40 )
-custom_fonts/normal_font = SubResource( 41 )
+margin_left = 20.0
+margin_top = 30.0
+margin_right = -30.0
+margin_bottom = -30.0
+custom_fonts/italics_font = SubResource( 44 )
+custom_fonts/bold_font = SubResource( 45 )
+custom_fonts/normal_font = SubResource( 46 )
+custom_colors/default_color = Color( 1, 1, 1, 1 )
 bbcode_enabled = true
 bbcode_text = "[center][b]~Programming[/b]
 CenTdemeern1
@@ -504,47 +1092,39 @@ __meta__ = {
 [node name="Buttons" type="Control" parent="Menu"]
 margin_right = 40.0
 margin_bottom = 40.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Play" type="Button" parent="Menu/Buttons"]
-margin_left = 648.0
+margin_left = 634.0
 margin_top = 320.0
 margin_right = 898.0
 margin_bottom = 400.0
-custom_styles/pressed = SubResource( 42 )
-custom_styles/focus = SubResource( 43 )
-custom_styles/normal = SubResource( 44 )
-custom_fonts/font = SubResource( 45 )
-custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_fonts/font = SubResource( 51 )
 text = "Play Game"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Settings" type="Button" parent="Menu/Buttons"]
-margin_left = 648.0
+margin_left = 634.0
 margin_top = 408.0
 margin_right = 898.0
 margin_bottom = 488.0
-custom_styles/pressed = SubResource( 42 )
-custom_styles/focus = SubResource( 43 )
-custom_styles/normal = SubResource( 44 )
-custom_fonts/font = SubResource( 45 )
-custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_fonts/font = SubResource( 52 )
 text = "Settings"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Exit" type="Button" parent="Menu/Buttons"]
-margin_left = 648.0
+margin_left = 634.0
 margin_top = 496.0
 margin_right = 898.0
 margin_bottom = 576.0
-custom_styles/pressed = SubResource( 42 )
-custom_styles/focus = SubResource( 43 )
-custom_styles/normal = SubResource( 44 )
-custom_fonts/font = SubResource( 45 )
-custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_styles/normal = SubResource( 47 )
+custom_fonts/font = SubResource( 53 )
 text = "Quit"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -562,8 +1142,11 @@ stream = ExtResource( 19 )
 [connection signal="animation_finished" from="AnimatedSprite" to="AnimatedSprite" method="_on_AnimatedSprite_animation_finished"]
 [connection signal="finished" from="Start" to="." method="_on_Start_finished"]
 [connection signal="finished" from="LogoDrop" to="." method="_on_LogoDrop_finished"]
-[connection signal="pressed" from="Menu/SettingsWindow/Tabs/Mods/Minigames/MoveLeft" to="Menu/SettingsWindow/Tabs/Mods/Minigames" method="_on_MoveLeft_pressed"]
-[connection signal="pressed" from="Menu/SettingsWindow/Tabs/Mods/Minigames/MoveRight" to="Menu/SettingsWindow/Tabs/Mods/Minigames" method="_on_MoveRight_pressed"]
+[connection signal="tab_changed" from="Menu/SettingsWindow/Tabs" to="Menu" method="_on_Tabs_tab_changed"]
+[connection signal="pressed" from="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames/MoveLeft" to="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames" method="_on_MoveLeft_pressed"]
+[connection signal="pressed" from="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames/MoveRight" to="Menu/SettingsWindow/Tabs/Mods/VBoxContainer/Minigames" method="_on_MoveRight_pressed"]
+[connection signal="focus_entered" from="Menu/Buttons/Play" to="." method="shushsettings"]
 [connection signal="pressed" from="Menu/Buttons/Play" to="Menu" method="_on_Play_pressed"]
+[connection signal="focus_entered" from="Menu/Buttons/Settings" to="." method="shushsettings"]
 [connection signal="pressed" from="Menu/Buttons/Settings" to="Menu" method="_on_Settings_pressed"]
 [connection signal="pressed" from="Menu/Buttons/Exit" to="Menu" method="_on_Exit_pressed"]

--- a/Scripts/MainScene.gd
+++ b/Scripts/MainScene.gd
@@ -2,8 +2,6 @@ extends Node2D
 
 var demotimer = -1
 var can_press_start = false
-var block_demo = false
-
 func _ready():
 	if Global.fadeinMM:
 		modulate=Color(0,0,0)
@@ -13,7 +11,7 @@ func _ready():
 func _process(delta):
 	if !modulate.r>=1:
 		modulate=Color(clamp(modulate.r+delta*4,0,1),clamp(modulate.g+delta*4,0,1),clamp(modulate.b+delta*4,0,1))
-	if !block_demo:
+	if !$Menu.svisible:
 		if can_press_start:
 			if demotimer >= 0:
 				demotimer+=delta
@@ -21,16 +19,24 @@ func _process(delta):
 				demotimer=delta
 		if demotimer >= 30:
 			Global.change_scene("res://Scenes/Demo.tscn")
-	if Input.is_action_just_pressed("start"):
-		start_pressed()
+	
+		
 
-func _input(event):
+func _unhandled_input(event):
 	if event is InputEventScreenTouch:
 		if event.pressed and !$Menu.svisible:
 			if event.position.x>$LogoTL.global_position.x and event.position.y>$LogoTL.global_position.y and event.position.x<$LogoBR.global_position.x and event.position.y<$LogoBR.global_position.y:
 				start_pressed()
 			else:
 				$Menu.svisible=true
+	if event is InputEventKey:
+		if event.is_action_pressed("start"):
+			if !$Menu.svisible:
+				start_pressed()
+	if event is InputEventJoypadButton:
+		if event.is_action_pressed("start") and can_press_start:
+			$Menu.svisible = false
+			start_pressed()
 
 func start_pressed():
 	if can_press_start:
@@ -51,3 +57,7 @@ func _on_Start_finished():
 		Global.change_scene("res://Scenes/Game.tscn")
 	else:
 		Global.change_scene("res://Scenes/Demo.tscn")
+
+
+func shushsettings():
+	$Menu/SettingsWindow.hide()

--- a/Scripts/Menu.gd
+++ b/Scripts/Menu.gd
@@ -15,14 +15,13 @@ func _process(_delta):
 		self.svisible = false
 		$SettingsWindow.hide()
 	elif Input.is_action_just_pressed("button1") or Input.is_action_just_pressed("button2") or Input.is_action_just_pressed("up") or Input.is_action_just_pressed("down") or Input.is_action_just_pressed("left") or Input.is_action_just_pressed("right"):
+		if not self.svisible: $Buttons/Play.grab_focus()
 		self.svisible = true
 	if self.svisible:
-		$"..".block_demo=true
 		v+=(1-v)/4
 		if v>0.999:
 			v=1
 	else:
-		$"..".block_demo=false
 		v-=v/4
 		if v<0.001:
 			v=0
@@ -31,9 +30,29 @@ func _process(_delta):
 	$Buttons.modulate=Color(1,1,1,v)
 	self.visible=v!=0
 
+func _input(event):
+	if not (event is InputEventKey or event is InputEventJoypadButton): return
+	if $SettingsWindow.visible:
+		if event.is_action_pressed("tab_backward"):
+			get_tree().set_input_as_handled()
+			var t = $SettingsWindow/Tabs.current_tab
+			t -= 1
+			if t == -1: t += $SettingsWindow/Tabs.get_child_count()
+			$SettingsWindow/Tabs.current_tab = t
+			_on_Tabs_tab_changed(t)
+		elif event.is_action_pressed("tab_forward"):
+			get_tree().set_input_as_handled()
+			var t = $SettingsWindow/Tabs.current_tab
+			t = (t+1) % $SettingsWindow/Tabs.get_child_count()
+			$SettingsWindow/Tabs.current_tab = t
+			_on_Tabs_tab_changed(t)
+		
 
 func _on_Settings_pressed():
-	$SettingsWindow.popup()
+	self.accept_event()
+	$SettingsWindow.show()
+	$SettingsWindow/Tabs.current_tab = 0
+	$SettingsWindow/Tabs/Settings/VBoxContainer/Fullscreen.grab_focus()
 
 
 func _on_Play_pressed():
@@ -43,4 +62,12 @@ func _on_Play_pressed():
 
 
 func _on_Exit_pressed():
+	self.accept_event()
 	get_tree().quit()
+
+
+func _on_Tabs_tab_changed(tab):
+	if tab == 0:
+		$SettingsWindow/Tabs/Settings/VBoxContainer/Fullscreen.grab_focus()
+	elif tab == 1:
+		$SettingsWindow/Tabs/Mods/VBoxContainer/InvControls.grab_focus()

--- a/Scripts/MinigamesBlacklist.gd
+++ b/Scripts/MinigamesBlacklist.gd
@@ -5,35 +5,39 @@ func translate_file_to_minigame_name(s:String):
 
 func _ready():
 	for i in Global.minigames:
-		$ActiveMinigames.add_item(translate_file_to_minigame_name(i))
+		$HBoxContainer/ActiveMinigames.add_item(translate_file_to_minigame_name(i))
 	for i in Global.disabled_minigames:
-		$InactiveMinigames.add_item(translate_file_to_minigame_name(i))
+		$HBoxContainer/InactiveMinigames.add_item(translate_file_to_minigame_name(i))
 
-#func _process(_delta):
-#	pass
+func _input(event):
+	if not (event is InputEventKey): return
+	if event.is_action_pressed("left") and get_focus_owner() == $HBoxContainer/ActiveMinigames:
+		_on_MoveLeft_pressed(true)
+	if event.is_action_pressed("right") and get_focus_owner() == $HBoxContainer/InactiveMinigames:
+		_on_MoveRight_pressed(true)
 
-func _on_MoveLeft_pressed():
-	var selections = $ActiveMinigames.get_selected_items()
+func _on_MoveLeft_pressed(e=false):
+	var selections = $HBoxContainer/ActiveMinigames.get_selected_items()
 	if (selections as Array)==[]:
-		$"../../../../NG".play()
+		if not e: get_tree().get_root().get_children()[-1].get_node("Menu/NG").play()
 	else:
-		$"../../../../OK2".play()
+		get_tree().get_root().get_children()[-1].get_node("Menu/OK2").play()
 	selections.invert()
 	for i in selections:
 		Global.disabled_minigames.append(Global.minigames[i])
-		$InactiveMinigames.add_item(translate_file_to_minigame_name(Global.minigames[i]))
+		$HBoxContainer/InactiveMinigames.add_item(translate_file_to_minigame_name(Global.minigames[i]))
 		Global.minigames.remove(i)
-		$ActiveMinigames.remove_item(i)
+		$HBoxContainer/ActiveMinigames.remove_item(i)
 
-func _on_MoveRight_pressed():
-	var selections = $InactiveMinigames.get_selected_items()
+func _on_MoveRight_pressed(e=false):
+	var selections = $HBoxContainer/InactiveMinigames.get_selected_items()
 	if (selections as Array)==[]:
-		$"../../../../NG".play()
+		if not e: get_tree().get_root().get_children()[-1].get_node("Menu/NG").play()
 	else:
-		$"../../../../OK2".play()
+		get_tree().get_root().get_children()[-1].get_node("Menu/OK2").play()
 	selections.invert()
 	for i in selections:
 		Global.minigames.append(Global.disabled_minigames[i])
-		$ActiveMinigames.add_item(translate_file_to_minigame_name(Global.disabled_minigames[i]))
+		$HBoxContainer/ActiveMinigames.add_item(translate_file_to_minigame_name(Global.disabled_minigames[i]))
 		Global.disabled_minigames.remove(i)
-		$InactiveMinigames.remove_item(i)
+		$HBoxContainer/InactiveMinigames.remove_item(i)

--- a/project.godot
+++ b/project.godot
@@ -56,6 +56,23 @@ enabled=PoolStringArray( "res://addons/AsepriteWizard/plugin.cfg" )
 
 [input]
 
+tab_backward={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":true,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":4,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+tab_forward={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":5,"pressure":0.0,"pressed":false,"script":null)
+ ]
+}
+ui_focus_next={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777218,"unicode":0,"echo":false,"script":null)
+ ]
+}
 start={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"unicode":0,"echo":false,"script":null)


### PR DESCRIPTION
Does quite a lot to the current state of the game:
- Completely redesigns the settings window to be less of an eyesore
- Makes the menu and settings window fully controllable with keyboard and mouse
    - That involves changing how some of the current things work. For example, in the menus, pressing enter will no longer act as the start button, as the enter button is used for confirming.
    - When certain views are activated, the first button will be focused automatically, to enable non-mouse control.

Should work fine, it did in my tests, but I'm not accustomed to the project enough to be 100% sure.

Once this is merged, I'll also work on keyboard re-binding.
